### PR TITLE
fix(validate-address): updates to allow firebase installations

### DIFF
--- a/extensions/validate-address/functions/package.json
+++ b/extensions/validate-address/functions/package.json
@@ -1,6 +1,7 @@
 {
     "name": "validate-address-functions",
     "scripts": {
+        "prepare": "npm run build",
         "lint": "eslint --ext .js,.ts .",
         "build": "tsc",
         "serve": "npm run build && firebase emulators:start --only functions",
@@ -23,7 +24,8 @@
         "humps": "^2.0.1",
         "mocha": "^9.1.1",
         "shipengine": "^1.0.0",
-        "shipengine-firebase-common": "1.0.0"
+        "shipengine-firebase-common": "1.0.0",
+        "typescript": "^3.8.0"
     },
     "devDependencies": {
         "@types/chai": "^4.2.21",
@@ -34,8 +36,7 @@
         "eslint": "^7.6.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-import": "^2.22.0",
-        "firebase-functions-test": "^0.2.0",
-        "typescript": "^3.8.0"
+        "firebase-functions-test": "^0.2.0"
     },
     "private": true
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
         "lerna": "^4.0.0",
         "prettier": "^2.3.2"
     },
-    "dependencies": {
-        "is_js": "^0.9.0"
-    },
     "workspaces": ["libs/*", "extensions/*/functions"],
     "packageManager": "yarn@3.0.2"
 }


### PR DESCRIPTION
Firebase extensions will currently fail on installation as the lib files will be unavailable.

Adding the proposed `prepare` script will build the source at runtime and successfully install the extension.


Additionally, the `is_js` library required steps to build and caused a build failure, stated as needed types `@types/is_js`.