### PR TITLE
fix(*) added secret type to api key configuration

### DIFF
--- a/extensions/purchase-label/extension.yaml
+++ b/extensions/purchase-label/extension.yaml
@@ -111,6 +111,7 @@ params:
 
   - param: SHIPENGINE_API_KEY
     label: ShipEngine Api Key
+    type: secret
     description: >
       Api key found on the api dashboard.
     type: string

--- a/extensions/rates/extension.yaml
+++ b/extensions/rates/extension.yaml
@@ -111,6 +111,7 @@ params:
 
   - param: SHIPENGINE_API_KEY
     label: ShipEngine Api Key
+    type: secret
     description: >
       Api key found on the api dashboard.
     type: string

--- a/extensions/track-label/extension.yaml
+++ b/extensions/track-label/extension.yaml
@@ -111,6 +111,7 @@ params:
 
   - param: SHIPENGINE_API_KEY
     label: ShipEngine Api Key
+    type: secret
     description: >
       Api key found on the api dashboard.
     type: string

--- a/extensions/validate-address/extension.yaml
+++ b/extensions/validate-address/extension.yaml
@@ -112,6 +112,7 @@ params:
 
   - param: SHIPENGINE_API_KEY
     label: ShipEngine Api Key
+    type: secret
     description: >
       Api key found on the api dashboard.
     type: string


### PR DESCRIPTION
Upcoming changes will allow a `secret` type to define secrets and passwords. This adds the type to all instances of the Ship Engine Api key configuration