### PR TITLE
Fixing typo in externalServices

### DIFF
--- a/extensions/purchase-label/extension.yaml
+++ b/extensions/purchase-label/extension.yaml
@@ -38,7 +38,7 @@ billingRequired: true
 
 externalServices:
   - name: ShipEngine
-  - pricingUri: https://www.shipengine.com/pricing/
+    pricingUri: https://www.shipengine.com/pricing/
 
 roles:
   - role: datastore.user

--- a/extensions/rates/extension.yaml
+++ b/extensions/rates/extension.yaml
@@ -37,7 +37,7 @@ billingRequired: true
 
 externalServices:
   - name: ShipEngine
-  - pricingUri: https://www.shipengine.com/pricing/
+    pricingUri: https://www.shipengine.com/pricing/
 
 roles:
   - role: datastore.user

--- a/extensions/track-label/extension.yaml
+++ b/extensions/track-label/extension.yaml
@@ -38,7 +38,7 @@ billingRequired: true
 
 externalServices:
   - name: ShipEngine
-  - pricingUri: https://www.shipengine.com/pricing/
+    pricingUri: https://www.shipengine.com/pricing/
 
 roles:
   - role: datastore.user

--- a/extensions/validate-address/extension.yaml
+++ b/extensions/validate-address/extension.yaml
@@ -38,7 +38,7 @@ billingRequired: true
 
 externalServices:
   - name: ShipEngine
-  - pricingUri: https://www.shipengine.com/pricing/
+    pricingUri: https://www.shipengine.com/pricing/
 
 roles:
   - role: datastore.user


### PR DESCRIPTION
Noticed a small typo in the externalServices field of extension.yaml. This was showing up as  [{name: ShipEngine}, {pricingUrl: Shipengine.com/pricing}], but it should be [{name: ShipEngine, pricingUrl: Shipengine.com/pricing}]