### PR TITLE
Update TypeScript versions

### DIFF
--- a/extensions/purchase-label/functions/package.json
+++ b/extensions/purchase-label/functions/package.json
@@ -24,7 +24,7 @@
     "firebase-functions": "^3.14.1",
     "shipengine": "^1.0.0",
     "shipengine-firebase-common-lib": "^1.0.0",
-    "typescript": "^3.8.0"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",

--- a/extensions/rates/functions/package.json
+++ b/extensions/rates/functions/package.json
@@ -24,7 +24,7 @@
     "firebase-functions": "^3.14.1",
     "shipengine": "^1.0.0",
     "shipengine-firebase-common-lib": "^1.0.0",
-    "typescript": "^3.8.0"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",

--- a/extensions/track-label/functions/package.json
+++ b/extensions/track-label/functions/package.json
@@ -28,7 +28,7 @@
     "humps": "^2.0.1",
     "shipengine": "^1.0.0",
     "shipengine-firebase-common-lib": "^1.0.0",
-    "typescript": "^3.8.0",
+    "typescript": "^4.7.4",
     "@types/humps": "^2.0.1"
   },
   "devDependencies": {

--- a/extensions/validate-address/functions/package.json
+++ b/extensions/validate-address/functions/package.json
@@ -24,7 +24,7 @@
     "firebase-functions": "^3.14.1",
     "shipengine": "^1.0.0",
     "shipengine-firebase-common-lib": "^1.0.0",
-    "typescript": "^3.8.0"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@types/chai": "^4.2.21",


### PR DESCRIPTION
fixes #40

`@types/humps` requires a minimum typescript version of `4.*`